### PR TITLE
FIx that rack_test_json does only GET mistakenly

### DIFF
--- a/lib/capybara/rack_test_json/client.rb
+++ b/lib/capybara/rack_test_json/client.rb
@@ -13,7 +13,7 @@ module Capybara::RackTestJson
     %w[ get post put delete ].each do |method|
       module_eval %{
         def #{method}(uri, params = {}, env = {}, &block)
-          env.merge(:method => "#{method.upcase}", :params => params)
+          env.merge!(:method => "#{method.upcase}", :params => params)
           if options[:follow_redirect]
             request_with_follow_redirect(uri, env, &block)
           else


### PR DESCRIPTION
Sorry, but I could not create a test which fails before, but succeeds now. 
