### PR TITLE
Add __FILE__ and __LINE__ so that pry can find generated methods

### DIFF
--- a/lib/capybara/httpclient_json/driver.rb
+++ b/lib/capybara/httpclient_json/driver.rb
@@ -67,11 +67,11 @@ class Capybara::HTTPClientJson::Driver < Capybara::Json::Driver::Base
   end
 
   %w[ get delete ].each do |method|
-    class_eval %{
+    class_eval <<-DEF, __FILE__, __LINE__ + 1
       def #{method}!(url, params = {}, env = {})
         handle_error { #{method}(url, params, env) }
       end
-    }
+    DEF
   end
 
   %w[ post put ].each do |method|

--- a/lib/capybara/json.rb
+++ b/lib/capybara/json.rb
@@ -15,19 +15,19 @@ module Capybara
     end
 
     %w[ get get! delete delete! ].each do |method|
-      module_eval %{
+      module_eval <<-DEF, __FILE__, __LINE__ + 1
         def #{method}(path, params = {}, env = {})
           page.driver.#{method}(path, params, env)
         end
-      }
+      DEF
     end
 
     %w[ post post! put put! ].each do |method|
-      module_eval %{
+      module_eval <<-DEF, __FILE__, __LINE__ + 1
         def #{method}(path, json, env = {})
           page.driver.#{method}(path, json, env)
         end
-      }
+      DEF
     end
 
     autoload :Error, 'capybara/json/error'

--- a/lib/capybara/rack_test_json/client.rb
+++ b/lib/capybara/rack_test_json/client.rb
@@ -11,7 +11,7 @@ module Capybara::RackTestJson
     end
 
     %w[ get post put delete ].each do |method|
-      module_eval %{
+      module_eval <<-DEF, __FILE__, __LINE__+1
         def #{method}(uri, params = {}, env = {}, &block)
           env = env.merge(:method => "#{method.upcase}", :params => params)
           if options[:follow_redirect]
@@ -20,7 +20,7 @@ module Capybara::RackTestJson
             request(uri, env)
           end
         end
-      }
+      DEF
     end
 
     def request_with_follow_redirect(uri, env)

--- a/lib/capybara/rack_test_json/driver.rb
+++ b/lib/capybara/rack_test_json/driver.rb
@@ -19,7 +19,7 @@ class Capybara::RackTestJson::Driver < Capybara::Json::Driver::Base
   alias response last_response
 
   %w[ get delete ].each do |method|
-    class_eval %{
+    class_eval <<-DEF, __FILE__, __LINE__ + 1
       def #{method}(path, params = {}, env = {})
         client.#{method}(path, params, env_for_rack(env))
       end
@@ -27,12 +27,12 @@ class Capybara::RackTestJson::Driver < Capybara::Json::Driver::Base
       def #{method}!(path, params = {}, env = {})
         handle_error { #{method}(path, params, env) }
       end
-    }
+    DEF
   end
   alias visit get
 
   %w[ post put ].each do |method|
-    class_eval %{
+    class_eval <<-DEF, __FILE__, __LINE__ + 1
       def #{method}(path, json, env = {})
         json = MultiJson.dump(json) unless json.is_a?(String)
 
@@ -48,7 +48,7 @@ class Capybara::RackTestJson::Driver < Capybara::Json::Driver::Base
       def #{method}!(path, json, env = {})
         handle_error { #{method}(path, json, env) }
       end
-    }
+    DEF
   end
 
   def current_url


### PR DESCRIPTION
This avoids the error when stepping into get:

```
Error: Cannot open "(eval)" for reading.
```
